### PR TITLE
1 1 seminar mock datenbereitstellen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,15 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/ch/bfh/bti7081/model/manager/FaqManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/FaqManager.java
@@ -1,7 +1,8 @@
 package ch.bfh.bti7081.model.manager;
 
 import ch.bfh.bti7081.model.faq.FaqEntry;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+
 
 import java.util.List;
 
@@ -9,19 +10,19 @@ public class FaqManager {
     // manages the communication between backend and frontend
     // the list of methods isn't completed yet, just some sample methods for the class diagramm
 
-    public List<FaqEntry> getAllWikiEntries() {
-        throw new NotImplementedException();
+    public List<FaqEntry> getAllWikiEntries()  {
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
-    public List<FaqEntry> getFilteredWikiEntries(String titleFilter) {
-        throw new NotImplementedException();
+    public List<FaqEntry> getFilteredWikiEntries(String titleFilter){
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
-    public FaqEntry createFaqEntry(FaqEntry entry) {
-        throw new NotImplementedException();
+    public FaqEntry createFaqEntry(FaqEntry entry){
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
     public void deleteFaqEntry(Integer id) {
-        throw new NotImplementedException();
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 }

--- a/src/main/java/ch/bfh/bti7081/model/manager/ForumManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/ForumManager.java
@@ -3,7 +3,6 @@ package ch.bfh.bti7081.model.manager;
 import ch.bfh.bti7081.model.dto.ForumEntryDTO;
 import ch.bfh.bti7081.model.forum.ForumCategory;
 import ch.bfh.bti7081.model.forum.ForumEntry;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.List;
 
@@ -12,19 +11,19 @@ public class ForumManager {
     // the list of methods isn't completed yet, just some sample methods for the class diagramm
 
     public List<ForumEntry> getAllEntriesByCategory(ForumCategory category) {
-        throw new NotImplementedException();
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
-    public ForumEntryDTO getForumEntry(Integer id) {
-        throw new NotImplementedException();
+    public ForumEntryDTO getForumEntry(Integer id)  {
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
-    public ForumEntryDTO createForumEntry(ForumEntryDTO forumEntryDTO) {
-        throw new NotImplementedException();
+    public ForumEntryDTO createForumEntry(ForumEntryDTO forumEntryDTO){
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
-    public void deleteForumEntry(Integer id) {
-        throw new NotImplementedException();
+    public void deleteForumEntry(Integer id) throws Exception {
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
 }

--- a/src/main/java/ch/bfh/bti7081/model/manager/SeminarCategoryManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/SeminarCategoryManager.java
@@ -1,0 +1,22 @@
+package ch.bfh.bti7081.model.manager;
+
+import ch.bfh.bti7081.model.seminar.SeminarCategory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SeminarCategoryManager {
+    public static List<SeminarCategory> getSeminarCategories(){
+        return mockCategories();
+    }
+
+    private static List<SeminarCategory> mockCategories() {
+        //These is mock data, nothing here is productive code.
+        List<SeminarCategory> mockSeminaryCategories = new ArrayList<>();
+        mockSeminaryCategories.add(new SeminarCategory("Betroffene helfen Betroffenen"));
+        mockSeminaryCategories.add(new SeminarCategory("Angehörige erzählen"));
+        mockSeminaryCategories.add(new SeminarCategory("Ärzte geben Auskunft"));
+        mockSeminaryCategories.add(new SeminarCategory("Allgemeines"));
+        return mockSeminaryCategories;
+    }
+}

--- a/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
@@ -1,7 +1,6 @@
 package ch.bfh.bti7081.model.manager;
 
 import ch.bfh.bti7081.model.seminar.Seminar;
-import ch.bfh.bti7081.model.seminar.SeminarCategory;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.ArrayList;
@@ -35,4 +34,67 @@ public class SeminarManager {
     public void deleteSeminar(Integer id) {
         throw new NotImplementedException();
     }
+
+    private static List<Seminar> mockSeminaries(){
+        //These is mock data, nothing here is productive code.
+        List<Seminar> mockSeminaries = new ArrayList<>();
+        Seminar seminarMock1=new Seminar();
+        seminarMock1.setCategory(SeminarCategoryManager.getSeminarCategories().get(3));
+        seminarMock1.setDate(dateGenerator("2019-11-07 13:30"));
+        seminarMock1.setDescription("Ärzte berichten von ihren Erlebnissen mit der Krankheit. Dr. Luis Alvador gibt Ihnen einen Überblick über die medizinischen Informationen, eine Podiumsdiskussion mit Angehörigen findet statt.");
+        seminarMock1.setHouseNumber("102");
+        seminarMock1.setLink("https://vaadin.com");
+        seminarMock1.setLocation("Bern");
+        seminarMock1.setTitle("Wie unterstütze ich einen Angehörigen?");
+        seminarMock1.setStreet("Wankdorffeldstrasse");
+        seminarMock1.setPlz(3014);
+        mockSeminaries.add(seminarMock1);
+
+        Seminar seminarMock2=new Seminar();
+        seminarMock2.setCategory(SeminarCategoryManager.getSeminarCategories().get(1));
+        seminarMock2.setDate(dateGenerator("2019-08-07 10:30"));
+        seminarMock2.setDescription("Betroffene erzählen von Ihren Problemen im Umgang mit der Krankheit und zeigen wie Sie diese tagtäglich überwinden.");
+        seminarMock2.setHouseNumber("5");
+        seminarMock2.setLink("https://www.nzz.ch/");
+        seminarMock2.setLocation("Bern");
+        seminarMock2.setTitle("Sozialphobie - Mit der Angst umgehen");
+        seminarMock2.setStreet(" Schanzenstrasse");
+        seminarMock2.setPlz(3008);
+        mockSeminaries.add(seminarMock2);
+
+        Seminar seminarMock3=new Seminar();
+        seminarMock3.setCategory(SeminarCategoryManager.getSeminarCategories().get(2));
+        seminarMock3.setDate(dateGenerator("2019-09-09 20:00"));
+        seminarMock3.setDescription("Wir haben zehn Angehörige von Personen mit Sozialphobie eingeladen, die Ihnen von Ihren Erlebnissen erzählen. Treffen Sie uns zu einem Feierabendbier. Mehr unter dem Link. ");
+        seminarMock3.setHouseNumber("18");
+        seminarMock3.setLink("https://www.zeit.de/index");
+        seminarMock3.setLocation("Rothrist");
+        seminarMock3.setTitle("Angehörigentreffen");
+        seminarMock3.setStreet("Bachweg");
+        seminarMock3.setPlz(4852);
+        mockSeminaries.add(seminarMock3);
+
+        Seminar seminarMock4=new Seminar();
+        seminarMock4.setCategory(SeminarCategoryManager.getSeminarCategories().get(1));
+        seminarMock4.setDate(dateGenerator("2020-02-15 09:00"));
+        seminarMock4.setDescription("Ein Treffen mit anderen Betroffenen. Hier können Sie sich entspannt fühlen, niemand wird sie verurteilen, da wir dasselbe tagtäglich auch durchmachen.");
+        seminarMock4.setHouseNumber("420");
+        seminarMock4.setLink("https://de.wikipedia.org/wiki/Soziale_Phobie");
+        seminarMock4.setLocation("Zürich");
+        seminarMock4.setTitle("Betroffenenhöck");
+        seminarMock4.setStreet("Badenerstrasse");
+        seminarMock4.setPlz(8040);
+        mockSeminaries.add(seminarMock4);
+
+        return mockSeminaries;
+    }
+
+    private static LocalDateTime dateGenerator(String timeToParse){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        LocalDateTime formatDateTime = LocalDateTime.parse(timeToParse, formatter);
+        return formatDateTime;
+    }
+
+
+
 }

--- a/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
@@ -1,7 +1,6 @@
 package ch.bfh.bti7081.model.manager;
 
 import ch.bfh.bti7081.model.seminar.Seminar;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -18,24 +17,26 @@ public class SeminarManager {
     }
 
     public List<Seminar> getFilteredSeminars(Map<String, String> filters) {
-        throw new NotImplementedException();
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
     public Seminar createSeminar(Seminar seminar) {
-        throw new NotImplementedException();
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
     public void deleteSeminar(Integer id) {
-        throw new NotImplementedException();
+        throw new IllegalArgumentException("Not implemented yet.");
     }
 
     private static List<Seminar> mockSeminaries(){
         //These is mock data, nothing here is productive code.
         List<Seminar> mockSeminaries = new ArrayList<>();
         Seminar seminarMock1=new Seminar();
-        seminarMock1.setCategory(SeminarCategoryManager.getSeminarCategories().get(3));
+        seminarMock1.setCategory(SeminarCategoryManager.getSeminarCategories().get(2));
         seminarMock1.setDate(dateGenerator("2019-11-07 13:30"));
-        seminarMock1.setDescription("Ärzte berichten von ihren Erlebnissen mit der Krankheit. Dr. Luis Alvador gibt Ihnen einen Überblick über die medizinischen Informationen, eine Podiumsdiskussion mit Angehörigen findet statt.");
+        seminarMock1.setDescription("Ärzte berichten von ihren Erlebnissen mit der Krankheit. " +
+                "Dr. Luis Alvador gibt Ihnen einen Überblick über die medizinischen Informationen, " +
+                "eine Podiumsdiskussion mit Angehörigen findet statt.");
         seminarMock1.setHouseNumber("102");
         seminarMock1.setLink("https://vaadin.com");
         seminarMock1.setLocation("Bern");
@@ -45,9 +46,10 @@ public class SeminarManager {
         mockSeminaries.add(seminarMock1);
 
         Seminar seminarMock2=new Seminar();
-        seminarMock2.setCategory(SeminarCategoryManager.getSeminarCategories().get(1));
+        seminarMock2.setCategory(SeminarCategoryManager.getSeminarCategories().get(0));
         seminarMock2.setDate(dateGenerator("2019-08-07 10:30"));
-        seminarMock2.setDescription("Betroffene erzählen von Ihren Problemen im Umgang mit der Krankheit und zeigen wie Sie diese tagtäglich überwinden.");
+        seminarMock2.setDescription("Betroffene erzählen von Ihren Problemen im Umgang mit der Krankheit " +
+                "und zeigen wie Sie diese tagtäglich überwinden.");
         seminarMock2.setHouseNumber("5");
         seminarMock2.setLink("https://www.nzz.ch/");
         seminarMock2.setLocation("Bern");
@@ -57,9 +59,11 @@ public class SeminarManager {
         mockSeminaries.add(seminarMock2);
 
         Seminar seminarMock3=new Seminar();
-        seminarMock3.setCategory(SeminarCategoryManager.getSeminarCategories().get(2));
+        seminarMock3.setCategory(SeminarCategoryManager.getSeminarCategories().get(1));
         seminarMock3.setDate(dateGenerator("2019-09-09 20:00"));
-        seminarMock3.setDescription("Wir haben zehn Angehörige von Personen mit Sozialphobie eingeladen, die Ihnen von Ihren Erlebnissen erzählen. Treffen Sie uns zu einem Feierabendbier. Mehr unter dem Link. ");
+        seminarMock3.setDescription("Wir haben zehn Angehörige von Personen mit Sozialphobie eingeladen, " +
+                "die Ihnen von Ihren Erlebnissen erzählen. Treffen Sie uns zu einem Feierabendbier. " +
+                "Mehr unter dem Link. ");
         seminarMock3.setHouseNumber("18");
         seminarMock3.setLink("https://www.zeit.de/index");
         seminarMock3.setLocation("Rothrist");
@@ -69,9 +73,10 @@ public class SeminarManager {
         mockSeminaries.add(seminarMock3);
 
         Seminar seminarMock4=new Seminar();
-        seminarMock4.setCategory(SeminarCategoryManager.getSeminarCategories().get(1));
+        seminarMock4.setCategory(SeminarCategoryManager.getSeminarCategories().get(0));
         seminarMock4.setDate(dateGenerator("2020-02-15 09:00"));
-        seminarMock4.setDescription("Ein Treffen mit anderen Betroffenen. Hier können Sie sich entspannt fühlen, niemand wird sie verurteilen, da wir dasselbe tagtäglich auch durchmachen.");
+        seminarMock4.setDescription("Ein Treffen mit anderen Betroffenen. Hier können Sie sich entspannt " +
+                "fühlen, niemand wird sie verurteilen, da wir dasselbe tagtäglich auch durchmachen.");
         seminarMock4.setHouseNumber("420");
         seminarMock4.setLink("https://de.wikipedia.org/wiki/Soziale_Phobie");
         seminarMock4.setLocation("Zürich");

--- a/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
@@ -1,8 +1,10 @@
 package ch.bfh.bti7081.model.manager;
 
 import ch.bfh.bti7081.model.seminar.Seminar;
+import ch.bfh.bti7081.model.seminar.SeminarCategory;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +20,14 @@ public class SeminarManager {
         throw new NotImplementedException();
     }
 
+    public List<SeminarCategory> getCategories(){
+        List<SeminarCategory> mockSeminaries = new ArrayList<>();
+        mockSeminaries.add(new SeminarCategory("Betroffene helfen Betroffenen"));
+        mockSeminaries.add(new SeminarCategory("Angehörige erzählen"));
+        mockSeminaries.add(new SeminarCategory("Ärzte geben Auskunft"));
+        mockSeminaries.add(new SeminarCategory("Allgemeines"));
+        return mockSeminaries;
+    }
     public Seminar createSeminar(Seminar seminar) {
         throw new NotImplementedException();
     }

--- a/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/SeminarManager.java
@@ -3,6 +3,8 @@ package ch.bfh.bti7081.model.manager;
 import ch.bfh.bti7081.model.seminar.Seminar;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,22 +13,14 @@ public class SeminarManager {
     // manages the communication between backend and frontend
     // the list of methods isn't completed yet, just some sample methods for the class diagramm
 
-    public List<Seminar> getSeminars() {
-        throw new NotImplementedException();
+    public static List<Seminar> getSeminaries() {
+        return mockSeminaries();
     }
 
     public List<Seminar> getFilteredSeminars(Map<String, String> filters) {
         throw new NotImplementedException();
     }
 
-    public List<SeminarCategory> getCategories(){
-        List<SeminarCategory> mockSeminaries = new ArrayList<>();
-        mockSeminaries.add(new SeminarCategory("Betroffene helfen Betroffenen"));
-        mockSeminaries.add(new SeminarCategory("Angehörige erzählen"));
-        mockSeminaries.add(new SeminarCategory("Ärzte geben Auskunft"));
-        mockSeminaries.add(new SeminarCategory("Allgemeines"));
-        return mockSeminaries;
-    }
     public Seminar createSeminar(Seminar seminar) {
         throw new NotImplementedException();
     }

--- a/src/main/java/ch/bfh/bti7081/model/manager/UserManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/UserManager.java
@@ -1,13 +1,40 @@
 package ch.bfh.bti7081.model.manager;
 
-import ch.bfh.bti7081.model.seminar.Seminar;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import ch.bfh.bti7081.model.User;
 
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class UserManager {
-    public static List<Seminar> getUserById(Integer id) {
-        throw new NotImplementedException();
+    public static User getUserByUsername(String name) {
+        Optional<User> user = getMockUsers().stream().filter(u -> u.getUsername().equals(name)).findAny();
+        if(user.isPresent()){
+            return user.get();
+        }else{
+            throw new SecurityException("Benutzer nicht da.");
+        }
+
     }
+
+    private static List<User> getMockUsers(){
+        //These is mock data, nothing here is productive code.
+        List<User> mockUsers = new ArrayList<>();
+        User mockUser1 = new User();
+        mockUser1.setEmail("nomail@nomailhausen.com");
+        mockUser1.setPassword("12345");
+        mockUser1.setPermission(1);
+        mockUser1.setUsername("Lara");
+        mockUsers.add(mockUser1);
+        User mockUser2 = new User();
+        mockUser2.setEmail("nomail@nomailhausen.com");
+        mockUser2.setPassword("12345");
+        mockUser2.setPermission(4);
+        mockUser2.setUsername("Admin");
+        mockUsers.add(mockUser2);
+        return mockUsers;
+    }
+
 
 }

--- a/src/main/java/ch/bfh/bti7081/model/manager/UserManager.java
+++ b/src/main/java/ch/bfh/bti7081/model/manager/UserManager.java
@@ -1,0 +1,13 @@
+package ch.bfh.bti7081.model.manager;
+
+import ch.bfh.bti7081.model.seminar.Seminar;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.List;
+
+public class UserManager {
+    public static List<Seminar> getUserById(Integer id) {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/main/java/ch/bfh/bti7081/model/seminar/SeminarCategory.java
+++ b/src/main/java/ch/bfh/bti7081/model/seminar/SeminarCategory.java
@@ -7,6 +7,10 @@ public class SeminarCategory {
         return name;
     }
 
+    public SeminarCategory(String name){
+        this.name=name;
+    }
+
     public void setName(String name) {
         this.name = name;
     }

--- a/src/main/test/MockTest.java
+++ b/src/main/test/MockTest.java
@@ -1,0 +1,21 @@
+import ch.bfh.bti7081.model.manager.SeminarCategoryManager;
+import ch.bfh.bti7081.model.manager.UserManager;
+import ch.bfh.bti7081.model.seminar.SeminarCategory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+
+public class MockTest {
+    @Test
+    public void UserTester(){
+        Assert.assertEquals(4,(long)UserManager.getUserByUsername("Admin").getPermission());
+    }
+
+    @Test
+    public void SeminarCategoryTester(){
+        List<SeminarCategory> test = SeminarCategoryManager.getSeminarCategories();
+        Assert.assertEquals("Allgemeines",test.get(3).getName());
+    }
+}

--- a/src/main/test/MockTest.java
+++ b/src/main/test/MockTest.java
@@ -1,4 +1,5 @@
 import ch.bfh.bti7081.model.manager.SeminarCategoryManager;
+import ch.bfh.bti7081.model.manager.SeminarManager;
 import ch.bfh.bti7081.model.manager.UserManager;
 import ch.bfh.bti7081.model.seminar.SeminarCategory;
 import org.junit.Assert;
@@ -18,4 +19,10 @@ public class MockTest {
         List<SeminarCategory> test = SeminarCategoryManager.getSeminarCategories();
         Assert.assertEquals("Allgemeines",test.get(3).getName());
     }
+
+    @Test
+    public void SeminarTester(){
+        Assert.assertEquals(4,SeminarManager.getSeminaries().size());
+    }
+
 }


### PR DESCRIPTION
Mocks für Seminare und User werden bei den Gettern auf den Managern zur Verfügung gestellt. Die Mock-Klassen sind privat. 
Anpassungen an den Mock-Daten werden durch den Change von Nadine vermutlich nochmals notwendig werden.
Weitere Anpassungen:

- JUnit-Tests im Maven
- JUnit-Test-Ordner und Mock-Tester-Klasse
- Exceptions in den Managern geändert da nicht gefunden beim Kompilieren
- UserManager-Klasse (neu)
- SeminarKategorieKlasse (neu)